### PR TITLE
Add support for EL7

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: update root trust anchor
+  command: "{{ update_root_trust_anchor }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,9 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+  - name: EL
+    versions:
+    - 7
   galaxy_tags: 
    - marathon
 

--- a/tasks/enable_ssl.yml
+++ b/tasks/enable_ssl.yml
@@ -1,11 +1,13 @@
 - name: Ensure local certs directory exists
-  file: state=directory path=/usr/local/share/ca-certificates
+  file: state=directory path={{ trust_anchor_root_dir }}
 
 - name: Install rootCA certificate
-  copy: src=rootCA.crt dest=/usr/local/share/ca-certificates/rootCA.crt
+  copy: src=rootCA.crt dest={{ trust_anchor_root_dir }}/rootCA.crt
+  notify:
+    - update root trust anchor
 
-- name: Update cert index
-  shell: /usr/sbin/update-ca-certificates
+# Force handler flush so that the rootCA is immediately taken into account
+- meta: flush_handlers
 
 - name: Copy root CA key and crt
   copy: src={{item}} dest=/tmp/{{item}}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,16 @@
-- name: Install openjdk
-  apt: name="openjdk-7-jre-headless" state=present
+- name: Fail if the OS is not supported
+  fail:
+    msg="This role is not supported on {{ansible_distribution}}"
+  when: "ansible_distribution != 'Ubuntu' and ansible_os_family != 'RedHat'"
 
+- name: Include distribution-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "vars/{{ ansible_distribution|lower }}.yml"
+    - "vars/{{ ansible_os_family|lower }}.yml"
+
+- name: Install OpenJDK 7
+  package: name="{{ openjdk_7_headless }}" state=present
 
 - name: Check that the certificates exists
   stat: path=marathon.key
@@ -38,7 +48,7 @@
       MARATHON_HTTPS_PORT: "{{ marathon_https_port }}"
       MARATHON_SSL_KEYSTORE_PASSWORD: "{{ marathon_jks_password }}"
       MARATHON_SSL_KEYSTORE_PATH: "{{ marathon_keystore_path }}"
-      MARATHON_HTTP_CREDENTIALS: "{{marathon_username}}:{{marathon_password}}"
+      MARATHON_HTTP_CREDENTIALS: "{{marathon_username}}:{{marathon_password|mandatory}}"
   tags: marathon
 
 
@@ -55,6 +65,7 @@
   retries: 3
   delay: 10
   changed_when: false
+  when: service_discovery == "consul"
   tags:
     - marathon
 

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,5 @@
+---
+# Package names and commands for EL
+openjdk_7_headless: java-1.7.0-openjdk-headless
+trust_anchor_root_dir: /etc/pki/ca-trust/source/anchors
+update_root_trust_anchor: update-ca-trust

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,0 +1,5 @@
+---
+# Package names and commands for Ubuntu
+openjdk_7_headless: openjdk-7-jre-headless
+trust_anchor_root_dir: /usr/local/share/ca-certificates
+update_root_trust_anchor: update-ca-certificates


### PR DESCRIPTION
Modifications are minimal and only affect certificate registration in the root trust store and package names.

Also, an unconditional service registration in Consul has been found and modified to run only if `service_discovery == "consul"`.
