### PR TITLE
Fix hardcoded eth0 in defaults/main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ zookeeper_peers_nodes: "
 	{%- if zookeeper_peers is defined -%}
             {% for host in zookeeper_peers %}{{host}}:{{zookeeper_client_port}}{% if not loop.last %},{% endif %}{% endfor %}
 	{%- else -%}
-            {%- for host in groups[zookeeper_server_group] -%}{{hostvars[host]['ansible_eth0']['ipv4']['address']}}:{{zookeeper_client_port}}{% if not loop.last %},{% endif %}{% endfor %} 
+            {%- for host in groups[zookeeper_server_group] -%}{{hostvars[host]['ansible_default_ipv4']['address']}}:{{zookeeper_client_port}}{% if not loop.last %},{% endif %}{% endfor %} 
 	{%- endif -%}
 "
 


### PR DESCRIPTION
This is a temporary fix which allows the role to work correctly on systems using biosdevname.
As it stands, it's suitable only for single-homed machines, support for multi-homed machines should be a longer-term goal.
